### PR TITLE
A lot of issues fixed

### DIFF
--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -1043,7 +1043,7 @@ function overrideWorkspaceDisplay() {
     tbStorage._getAlwaysZoomOut = OverviewControls.ThumbnailsSlider.prototype._getAlwaysZoomOut;
     OverviewControls.ThumbnailsSlider.prototype._getAlwaysZoomOut = function () {
         // *Always* show the pager when hovering or during a drag, regardless of width.
-        let alwaysZoomOut = this.actor.hover ||  this.inDrag;
+        let alwaysZoomOut = this.actor.hover ||  this._inDrag;
 
         // always zoom out if there is a monitor to the right of primary.
         if (!alwaysZoomOut) {

--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -151,13 +151,13 @@ const Convenience = Me.imports.convenience;
 const Prefs = Me.imports.prefs;
 var MyWorkspaceSwitcherPopup = Me.imports.myWorkspaceSwitcherPopup;
 
-var KEY_ROWS = Prefs.KEY_ROWS;
-var KEY_COLS = Prefs.KEY_COLS;
-var KEY_WRAPAROUND = Prefs.KEY_WRAPAROUND;
-var KEY_WRAP_TO_SAME = Prefs.KEY_WRAP_TO_SAME;
-var KEY_MAX_HFRACTION = Prefs.KEY_MAX_HFRACTION;
-var KEY_MAX_HFRACTION_COLLAPSE = Prefs.KEY_MAX_HFRACTION_COLLAPSE;
-var KEY_SHOW_WORKSPACE_LABELS = Prefs.KEY_SHOW_WORKSPACE_LABELS;
+const KEY_ROWS = Prefs.KEY_ROWS;
+const KEY_COLS = Prefs.KEY_COLS;
+const KEY_WRAPAROUND = Prefs.KEY_WRAPAROUND;
+const KEY_WRAP_TO_SAME = Prefs.KEY_WRAP_TO_SAME;
+const KEY_MAX_HFRACTION = Prefs.KEY_MAX_HFRACTION;
+const KEY_MAX_HFRACTION_COLLAPSE = Prefs.KEY_MAX_HFRACTION_COLLAPSE;
+const KEY_SHOW_WORKSPACE_LABELS = Prefs.KEY_SHOW_WORKSPACE_LABELS;
 
 const OVERRIDE_SCHEMA = 'org.gnome.shell.overrides'
 

--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -865,11 +865,11 @@ const ThumbnailsBox = new Lang.Class({
 
                 x += thumbnailWidth + spacing;
                 ++i;
-                if (i >= MAX_WORKSPACES) {
+                if (i >= MAX_WORKSPACES || i >= this._thumbnails.length) {
                     break;
                 }
             } // col loop
-            if (i >= MAX_WORKSPACES) {
+            if (i >= MAX_WORKSPACES || i >= this._thumbnails.length) {
                 break;
             }
             y += thumbnailHeight + spacing;

--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -149,7 +149,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 const Prefs = Me.imports.prefs;
-var MyWorkspaceSwitcherPopup = Me.imports.myWorkspaceSwitcherPopup;
+const MyWorkspaceSwitcherPopup = Me.imports.myWorkspaceSwitcherPopup;
 
 const KEY_ROWS = Prefs.KEY_ROWS;
 const KEY_COLS = Prefs.KEY_COLS;
@@ -458,7 +458,7 @@ function unoverrideKeybindingsAndPopup() {
                                                    Main.wm._showWorkspaceSwitcher));
     }
 
-    _workspaceSwitcherPopup = null;
+    Main.wm._workspaceSwitcherPopup = null;
 }
 
 // GNOME 3.2 & 3.4: Main.overview._workspacesDisplay
@@ -979,22 +979,24 @@ function overrideWorkspaceDisplay() {
         wvStorage._init.apply(this, arguments);
         Main.overview.connect('scroll-event', Lang.bind(this, function _horizontalScroll(actor, event) {
                 // same as the original, but for LEFT/RIGHT
-                if (!actor.mapped)
-                    return false;
+                // if (!actor.mapped)
+                //     return false;
                 let wsIndex =  global.screen.get_active_workspace_index();
 
                 switch (event.get_scroll_direction()) {
                     case Clutter.ScrollDirection.UP:
                         global.screen.workspace_grid.actionMoveWorkspace(wsIndex-1);
-                        return true;
+                        return Clutter.EVENT_STOP;
                     case Clutter.ScrollDirection.DOWN:
                         global.screen.workspace_grid.actionMoveWorkspace(wsIndex+1);
-                        return true;
+                        return Clutter.EVENT_STOP;
                 }
 
-                return false;
+                return Clutter.EVENT_PROPAGATE;
             }));
     };
+
+
 
     // 2. Replace workspacesDisplay._thumbnailsBox with my own.
     // Start with controls collapsed (since the workspace thumbnails can take

--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -1114,6 +1114,14 @@ function unoverrideWorkspaceDisplay() {
 }
 
 /******************
+* Sets org.gnome.shell.overrides.dynamic-workspaces schema to false
+*******************/
+function disableDynamicWorkspaces() {
+    let settings = global.get_overrides_settings();
+    settings.set_boolean('dynamic-workspaces', false);
+}
+
+/******************
  * tells Meta about the number of workspaces we want
  ******************/
 function modifyNumWorkspaces() {
@@ -1166,6 +1174,8 @@ function modifyNumWorkspaces() {
     // this forces the workspaces display to update itself to match the new
     // number of workspaces.
     global.screen.notify('n-workspaces');
+
+    disableDynamicWorkspaces();
 }
 
 function unmodifyNumWorkspaces() {

--- a/workspace-grid@mathematical.coffee.gmail.com/myWorkspaceSwitcherPopup.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/myWorkspaceSwitcherPopup.js
@@ -29,15 +29,15 @@ const Prefs          = Me.imports.prefs;
 
 const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup;
 
-const UP    = Meta.MotionDirection.UP;
-const DOWN  = Meta.MotionDirection.DOWN;
-const LEFT  = Meta.MotionDirection.LEFT;
-const RIGHT = Meta.MotionDirection.RIGHT;
+var UP    = Meta.MotionDirection.UP;
+var DOWN  = Meta.MotionDirection.DOWN;
+var LEFT  = Meta.MotionDirection.LEFT;
+var RIGHT = Meta.MotionDirection.RIGHT;
 
 /************
  * Workspace Switcher that can do rows and columns as opposed to just rows.
  ************/
-const myWorkspaceSwitcherPopup = new Lang.Class({
+var myWorkspaceSwitcherPopup = new Lang.Class({
     Name: 'myWorkspaceSwitcherPopup',
     Extends: WorkspaceSwitcherPopup.WorkspaceSwitcherPopup,
 

--- a/workspace-grid@mathematical.coffee.gmail.com/prefs.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/prefs.js
@@ -37,14 +37,14 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 
-const KEY_ROWS = 'num-rows';
-const KEY_COLS = 'num-columns';
-const KEY_WRAPAROUND = 'wraparound';
-const KEY_WRAP_TO_SAME = 'wrap-to-same';
-const KEY_MAX_HFRACTION = 'max-screen-fraction';
-const KEY_MAX_HFRACTION_COLLAPSE = 'max-screen-fraction-before-collapse';
-const KEY_SHOW_WORKSPACE_LABELS = 'show-workspace-labels';
-const KEY_RELATIVE_WORKSPACE_SWITCHING ="relative-workspace-switching";
+var KEY_ROWS = 'num-rows';
+var KEY_COLS = 'num-columns';
+var KEY_WRAPAROUND = 'wraparound';
+var KEY_WRAP_TO_SAME = 'wrap-to-same';
+var KEY_MAX_HFRACTION = 'max-screen-fraction';
+var KEY_MAX_HFRACTION_COLLAPSE = 'max-screen-fraction-before-collapse';
+var KEY_SHOW_WORKSPACE_LABELS = 'show-workspace-labels';
+var KEY_RELATIVE_WORKSPACE_SWITCHING ="relative-workspace-switching";
 
 function init() {
     Convenience.initTranslations();


### PR DESCRIPTION
In this pull request I removed more gjs warnings from #56, and solved the problem described in #47 which was just a variable name that changed in the latest versions of gnome-shell.

Also, letting the dynamic workspaces turned on was resulting in a bug, so I added a conditional to solve this in the iteration that allocates the thumbnails to stop correctly without exceeding the bounds of the thumbnails array. This may solve #17.

Finally, I fixed the issue described in #11.