### PR TITLE
Added border and fade-out animation to the thumbnails switcher

### DIFF
--- a/workspace-grid@mathematical.coffee.gmail.com/stylesheet.css
+++ b/workspace-grid@mathematical.coffee.gmail.com/stylesheet.css
@@ -25,6 +25,14 @@
     spacing: 8px;
 }
 
+.workspace-switcher-thumbnails {
+    background: rgba(238, 238, 238, 0.2);
+    border-width: 0px;
+    border-radius: 15px;
+    box-shadow: 0px 0px 0px 15px; /* top right bottom left */
+    spacing: 10px; /* used by imports.ui.workspaceSwitcherPopup */
+}
+
 .workspace-switcher-group {
     padding: 10px;
 }


### PR DESCRIPTION
### Description
Modified the thumbnails switcher to display a border and a fade-out animation, similar to what is observed in the switcher without thumbnails.

Besides, I believe that the `myWorkspaceSwitcherPopup._destroy` method was never called, so I changed it to `myWorkspaceSwitcherPopup.destroy` and removed the call to `self.parent._destroy`, since this was raising an error.

### Additional Information
The `myWorkspaceSwitcherPopup._onTimeout` method is basically a copy of `WorkspaceSwitcherPopup._onTimeout`, with an extra condition to animate the thumbnails switcher.