### PR TITLE
Option for thumbnails at the overview bottom

### DIFF
--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -956,6 +956,39 @@ function _replaceThumbnailsBoxActor (actorCallbackObject) {
     slider.actor.add_actor(thumbnailsBox.actor);
 }
 
+let switcher_placement_overriden = false;
+let bin_thumbnails = null;
+function overrideSwitcherPlacement(do_override) {
+    let controls = Main.overview._controls;
+    if (do_override && !switcher_placement_overriden) {
+        // Place the workspace switcher at the bottom //
+        //// Remove the thumbnails switcher from the overview
+        controls._group.remove_actor(controls._thumbnailsSlider.actor);
+        //// Add it again, but not to the main layout
+        bin_thumbnails = new St.Bin({
+            child: controls._thumbnailsSlider.actor,
+            x_align: St.Align.MIDDLE
+        });
+        Main.overview._overview.add(bin_thumbnails);
+        //// Refresh (not sure if this is needed)
+        refreshThumbnailsBox();
+        //// Record this modification
+        switcher_placement_overriden = true;
+    } else if (!do_override && switcher_placement_overriden) {
+        // Restore placement
+        //// Remove it from the from the overview outer layout
+        Main.overview._overview.remove_actor(bin_thumbnails);
+        bin_thumbnails.remove_actor(controls._thumbnailsSlider.actor);
+        bin_thumbnails.destroy();
+        //// Restore the switcher to its original location
+        controls._group.add_actor(controls._thumbnailsSlider.actor);
+        //// Refresh (not sure if this is needed)
+        refreshThumbnailsBox();
+        //// Record this modification
+        switcher_placement_overriden = false;
+    }
+}
+
 /**
  * We need to:
  * 1) override the scroll event on workspaces display to allow sideways
@@ -1263,6 +1296,11 @@ function enable() {
     signals.push(settings.connect('changed::' + KEY_COLS, nWorkspacesChanged));
     signals.push(settings.connect('changed::' + KEY_MAX_HFRACTION, refreshThumbnailsBox));
     signals.push(settings.connect('changed::' + KEY_MAX_HFRACTION_COLLAPSE, refreshThumbnailsBox));
+    
+    // Connect to the overlay key to modify the thumbnails box position if the user so desires
+    signals.push(global.display.connect('overlay-key', () => {
+        overrideSwitcherPlacement(settings.get_boolean(Prefs.KEY_PLACE_SWITCHER_BOTTOM));
+    }));
 }
 
 function disable() {

--- a/workspace-grid@mathematical.coffee.gmail.com/prefs.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/prefs.js
@@ -45,6 +45,7 @@ const KEY_MAX_HFRACTION = 'max-screen-fraction';
 const KEY_MAX_HFRACTION_COLLAPSE = 'max-screen-fraction-before-collapse';
 const KEY_SHOW_WORKSPACE_LABELS = 'show-workspace-labels';
 const KEY_RELATIVE_WORKSPACE_SWITCHING ="relative-workspace-switching";
+const KEY_PLACE_SWITCHER_BOTTOM = "place-switcher-bottom";
 
 function init() {
     Convenience.initTranslations();
@@ -98,6 +99,9 @@ const WorkspaceGridPrefsWidget = new GObject.Class({
 
         this.addBoolean(_("Show workspace labels in the switcher?"),
             KEY_SHOW_WORKSPACE_LABELS);
+
+        this.addBoolean(_("Place the overview workspace switcher at the bottom?"),
+            KEY_PLACE_SWITCHER_BOTTOM);
 
         item = new Gtk.Label({
             label: _("The following settings determine how much horizontal " +

--- a/workspace-grid@mathematical.coffee.gmail.com/schemas/org.gnome.shell.extensions.workspace-grid.gschema.xml
+++ b/workspace-grid@mathematical.coffee.gmail.com/schemas/org.gnome.shell.extensions.workspace-grid.gschema.xml
@@ -33,6 +33,11 @@
       <summary>Whether to show workspace names in the workspace switcher popup</summary>
       <description>Whether to show workspace names in the workspace switcher popup</description>
     </key>
+    <key type="b" name="place-switcher-bottom">
+      <default>false</default>
+      <summary>Whether to place the workspace switcher at the bottom of the overview screen</summary>
+      <description>Whether to place the workspace switcher at the bottom of the overview screen</description>
+    </key>
     <key type="d" name="max-screen-fraction">
       <default>0.7</default>
       <range min="0" max="1.0"/>


### PR DESCRIPTION
### Description
This is an attempt to solve #64.

Listed below are what I believe should be/have been done to solve this issue:
- [x] Place the ThumbnailsSlider element at the bottom of the overview.
- [x] Add an option for this in the preferences window.
- [ ] Adjust the width and overall layout of the box containing the thumbnails when they are at the bottom. The upper corners should be round instead of the ones on the left.
- [ ] Make the thumbnails slide down instead of right when they are at the bottom.

![screenshot from 2018-05-08 21-43-01](https://user-images.githubusercontent.com/5129986/39789879-f80b1556-5308-11e8-8d14-7dcb7b9f0fde.png)
### Additional Info
I am capturing the `overlay-key` (typically <kbd>WindowsKey</kbd>), which display the overview of windows and workspaces, and changing the thumbnails position if the user has selected this option in the preferences window. I tried to
```js
let bt_switcher = this.addBoolean(_("Place the overview workspace switcher at the bottom?"),
    KEY_PLACE_SWITCHER_BOTTOM);
bt_switcher.connect('state-set', Lang.bind(this, function(widget, flag_state) {
    Me.imports.extension.overrideSwitcherPlacement(flag_state);
});
```
But that did not work out. Is it because the preferences window runs in another thread?