### PR TITLE
Fixed the workspace indicator

### DIFF
--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -650,11 +650,6 @@ const ThumbnailsBox = new Lang.Class({
         }
 
         this._animatingIndicator = true;
-        let indicatorThemeNode = this._indicator.get_theme_node(),
-            indicatorTopFullBorder = indicatorThemeNode.get_padding(St.Side.TOP) + indicatorThemeNode.get_border_width(St.Side.TOP),
-            indicatorLeftFullBorder = indicatorThemeNode.get_padding(St.Side.LEFT) + indicatorThemeNode.get_border_width(St.Side.LEFT);
-        this.indicatorX = this._indicator.allocation.x1 + indicatorLeftFullBorder; // <-- added
-        this.indicatorY = this._indicator.allocation.y1 + indicatorTopFullBorder;
         Tweener.addTween(this,
                          { indicatorY: thumbnail.actor.allocation.y1,
                            indicatorX: thumbnail.actor.allocation.x1, // added
@@ -879,6 +874,10 @@ const ThumbnailsBox = new Lang.Class({
         childBox.x2 = (indicatorX2 ? indicatorX2 : (indicatorX1 + thumbnailWidth)) + indicatorLeftFullBorder;
         childBox.y1 = indicatorY1 - indicatorTopFullBorder;
         childBox.y2 = (indicatorY2 ? indicatorY2 : (indicatorY1 + thumbnailHeight)) + indicatorBottomFullBorder;
+        if (!this._animatingIndicator) {
+          this._indicatorX = indicatorX1;
+          this._indicatorY = indicatorY1;
+        }
         this._indicator.allocate(childBox, flags);
 
 


### PR DESCRIPTION
`_indicator.allocation` is undefined on newer version of Gnome