### PR TITLE
Gnome 3.30 support: MetaScreen has been removed

### DIFF
--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -1132,7 +1132,12 @@ function unoverrideWorkspaceDisplay() {
 * Sets org.gnome.shell.overrides.dynamic-workspaces schema to false
 *******************/
 function disableDynamicWorkspaces() {
-    let settings = global.get_overrides_settings();
+    let settings;
+    // Override schemas are gone in GNOME 3.30
+    if (global.get_overrides_settings)
+        settings = global.get_overrides_settings()
+    else
+        settings = new Gio.Settings({ schema_id: 'org.gnome.mutter' });
     settings.set_boolean('dynamic-workspaces', false);
 }
 

--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -31,8 +31,9 @@
  * If you wish to see if your extension is compatible with this, note:
  *
  * This extension exports a number of constants and functions to an object
- * global.screen.workspace_grid for your convenience. Note that this extension
- * must be enabled for this all to work. global.screen.workspace_grid contains:
+ * Utils.WS.getWS().workspace_grid for your convenience. Note that this
+ * extension must be enabled for this all to work.
+ * Utils.WS.getWS().workspace_grid contains:
  *
  *   (Exported Constants)
  *   - rows     : number of rows of workspaces
@@ -42,16 +43,16 @@
  *   - moveWorkspace : switches workspaces in the direction specified, being
  *                     either UP, LEFT, RIGHT or DOWN (see Meta.MotionDirection).
  *   - rowColToIndex : converts the row/column into an index for use with (e.g.)
- *                     global.screen.get_workspace_by_index(i)
- *   - indexToRowCol : converts an index (0 to global.screen.n_workspaces-1) to
- *                     a row and column
+ *                     Utils.WS.getWS().get_workspace_by_index(i)
+ *   - indexToRowCol : converts an index (0 to Utils.WS.getWS().n_workspaces-1)
+ *                     to a row and column
  *   - getWorkspaceSwitcherPopup : gets our workspace switcher popup so you
  *                                 can show it if you want
  *   - calculateWorkspace : returns the workspace index in the specified direction
  *                          to the current, taking into account wrapping.
  *
  * For example, to move to the workspace below us:
- *     const WorkspaceGrid = global.screen.workspace_grid;
+ *     const WorkspaceGrid = Utils.WS.getWS().workspace_grid;
  *     WorkspaceGrid.moveWorkspace(Meta.MotionDirection.DOWN);
  *
  * I am happy to try help/give an opinion/improve this extension to try make it
@@ -61,13 +62,13 @@
  * ---------------------------
  * Say you want to know the number of rows/columns of workspaces in your
  * extension. Then you have to wait for this extension to load and populate
- * global.screen.workspace_grid.
+ * Utils.WS.getWS().workspace_grid.
  *
  * When the workspace_grid extension enables or disables it fires a
  *  'notify::n_workspaces' signal on global.screen.
  *
  * You can connect to this and check for the existence (or removal) of
- * global.screen.workspace_grid.
+ * Utils.WS.getWS().workspace_grid.
  *
  * Further notes
  * -------------
@@ -150,6 +151,7 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 const Prefs = Me.imports.prefs;
 const MyWorkspaceSwitcherPopup = Me.imports.myWorkspaceSwitcherPopup;
+const Utils = Me.imports.utils;
 
 const KEY_ROWS = Prefs.KEY_ROWS;
 const KEY_COLS = Prefs.KEY_COLS;
@@ -212,15 +214,15 @@ let settings = 0;
 /***************
  * Helper functions
  ***************/
-/* Converts an index (from 0 to global.screen.n_workspaces) into [row, column]
+/* Converts an index (from 0 to Utils.WS.getWS().n_workspaces) into [row, column]
  * being the row and column of workspace `index` according to the user's layout.
  *
  * Row and column start from 0.
  */
 function indexToRowCol(index) {
     // row-major. 0-based.
-    return [Math.floor(index / global.screen.workspace_grid.columns),
-       index % global.screen.workspace_grid.columns];
+    return [Math.floor(index / Utils.WS.getWS().workspace_grid.columns),
+       index % Utils.WS.getWS().workspace_grid.columns];
 }
 
 /* Converts a row and column (0-based) into the index of that workspace.
@@ -230,7 +232,7 @@ function indexToRowCol(index) {
  */
 function rowColToIndex(row, col) {
     // row-major. 0-based.
-    let idx = row * global.screen.workspace_grid.columns + col;
+    let idx = row * Utils.WS.getWS().workspace_grid.columns + col;
     if (idx >= MAX_WORKSPACES) {
         idx = -1;
     }
@@ -254,7 +256,7 @@ function getWorkspaceSwitcherPopup() {
 
 // calculates the workspace index in that direction.
 function calculateWorkspace(direction, wraparound, wrapToSame) {
-    let from = global.screen.get_active_workspace(),
+    let from = Utils.WS.getWS().get_active_workspace(),
         to = from.get_neighbor(direction).index();
 
     if (!wraparound || from.index() !== to) {
@@ -266,7 +268,7 @@ function calculateWorkspace(direction, wraparound, wrapToSame) {
     switch (direction) {
         case LEFT:
             // we must be at the start of the row. go to the end of the row.
-            col = global.screen.workspace_grid.columns - 1;
+            col = Utils.WS.getWS().workspace_grid.columns - 1;
             if (!wrapToSame) row--;
             break;
         case RIGHT:
@@ -276,7 +278,7 @@ function calculateWorkspace(direction, wraparound, wrapToSame) {
             break;
         case UP:
             // we must be at the top of the col. go to the bottom of the same col.
-            row = global.screen.workspace_grid.rows - 1;
+            row = Utils.WS.getWS().workspace_grid.rows - 1;
             if (!wrapToSame) col--;
             break;
         case DOWN:
@@ -286,9 +288,9 @@ function calculateWorkspace(direction, wraparound, wrapToSame) {
             break;
     }
     if (col < 0 || row < 0) {
-        to = global.screen.n_workspaces - 1;
-    } else if (col > global.screen.workspace_grid.columns - 1 ||
-               row > global.screen.workspace_grid.rows - 1) {
+        to = Utils.WS.getWS().n_workspaces - 1;
+    } else if (col > Utils.WS.getWS().workspace_grid.columns - 1 ||
+               row > Utils.WS.getWS().workspace_grid.rows - 1) {
         to = 0;
     } else {
         to = rowColToIndex(row, col);
@@ -323,11 +325,25 @@ function moveWorkspace(direction) {
  * This is the same as WindowManager._showWorkspaceSwitcher but we don't
  * filter out RIGHT/LEFT actions like they do.
  */
-function showWorkspaceSwitcher(display, screen, window, binding) {
+function showWorkspaceSwitcher(display, arg2, arg3, arg4) {
+    let screen;
+    let window;
+    let binding;
+    // Note: in v3.30, the 2nd arg (screen that we don't need) has been removed
+    if (!arg4) {
+        screen = display.get_workspace_manager();
+        window = arg2;
+        binding = arg3;
+    } else {
+        screen = arg2;
+        window = arg3;
+        binding = arg4;
+    }
+
     if (!Main.sessionMode.hasWorkspaces)
         return;
 
-    if (global.screen.n_workspaces === 1)
+    if (Utils.WS.getWS().n_workspaces === 1)
         return;
 
     let [action,,,target] = binding.get_name().split('-');
@@ -356,9 +372,9 @@ function showWorkspaceSwitcher(display, screen, window, binding) {
         direction = Meta.MotionDirection[target.toUpperCase()];
     } else if (target > 0) {
         target--;
-		if (settings.get_boolean(Prefs.KEY_RELATIVE_WORKSPACE_SWITCHING)) {
-			target = target + Math.floor(screen.get_active_workspace_index() / global.screen.workspace_grid.columns ) * global.screen.workspace_grid.columns ;
-		}
+        if (settings.get_boolean(Prefs.KEY_RELATIVE_WORKSPACE_SWITCHING)) {
+            target = target + Math.floor(screen.get_active_workspace_index() / Utils.WS.getWS().workspace_grid.columns) * Utils.WS.getWS().workspace_grid.columns ;
+        }
         newWs = screen.get_workspace_by_index(target);
     }
 
@@ -385,7 +401,7 @@ function showWorkspaceSwitcher(display, screen, window, binding) {
 }
 
 function actionMoveWorkspace(destination) {
-    let from = global.screen.get_active_workspace_index();
+    let from = Utils.WS.getWS().get_active_workspace_index();
 
     let to;
     // destination >= 0 is workspace index, otherwise its a direction
@@ -396,11 +412,11 @@ function actionMoveWorkspace(destination) {
                                 settings.get_boolean(KEY_WRAPAROUND),
                                 settings.get_boolean(KEY_WRAP_TO_SAME));
 
-    let ws = global.screen.get_workspace_by_index(to);
+    let ws = Utils.WS.getWS().get_workspace_by_index(to);
 
     // if ws is null, the workspace does't exist, so keep on actual workspace
     if (ws == null) {
-        ws = global.screen.get_active_workspace();
+        ws = Utils.WS.getWS().get_active_workspace();
     }
 
     if (to !== from) {
@@ -419,9 +435,9 @@ function actionMoveWindow(window, destination) {
                                 settings.get_boolean(KEY_WRAPAROUND),
                                 settings.get_boolean(KEY_WRAP_TO_SAME));
 
-    let ws = global.screen.get_workspace_by_index(to);
+    let ws = Utils.WS.getWS().get_workspace_by_index(to);
 
-    if (to !== global.screen.get_active_workspace_index()) {
+    if (to !== Utils.WS.getWS().get_active_workspace_index()) {
         Main.wm._movingWindow = window;
         window.change_workspace(ws);
         global.display.clear_mouse_mode();
@@ -641,7 +657,7 @@ const ThumbnailsBox = new Lang.Class({
 
     _activeWorkspaceChanged: function () {
         let thumbnail;
-        let activeWorkspace = global.screen.get_active_workspace();
+        let activeWorkspace = Utils.WS.getWS().get_active_workspace();
         for (let i = 0; i < this._thumbnails.length; i++) {
             if (this._thumbnails[i].metaWorkspace === activeWorkspace) {
                 thumbnail = this._thumbnails[i];
@@ -672,7 +688,7 @@ const ThumbnailsBox = new Lang.Class({
         let themeNode    = this.actor.get_theme_node();
 
         let spacing      = themeNode.get_length('spacing');
-        let nWorkspaces  = global.screen.workspace_grid.rows;
+        let nWorkspaces  = Utils.WS.getWS().workspace_grid.rows;
         let totalSpacing = (nWorkspaces - 1) * spacing;
 
         alloc.min_size     = totalSpacing;
@@ -694,8 +710,8 @@ const ThumbnailsBox = new Lang.Class({
 
         let themeNode = this.actor.get_theme_node(),
             spacing = this.actor.get_theme_node().get_length('spacing'),
-            nRows = global.screen.workspace_grid.rows,
-            nCols = global.screen.workspace_grid.columns,
+            nRows = Utils.WS.getWS().workspace_grid.rows,
+            nCols = Utils.WS.getWS().workspace_grid.columns,
             totalSpacingX = (nCols - 1) * spacing,
             totalSpacingY = (nRows - 1) * spacing,
             availY = forHeight - totalSpacingY,
@@ -736,8 +752,8 @@ const ThumbnailsBox = new Lang.Class({
         let spacing = this.actor.get_theme_node().get_length('spacing');
 
         // Compute the scale we'll need once everything is updated
-        let nCols = global.screen.workspace_grid.columns,
-            nRows = global.screen.workspace_grid.rows,
+        let nCols = Utils.WS.getWS().workspace_grid.columns,
+            nRows = Utils.WS.getWS().workspace_grid.rows,
             totalSpacingY = (nRows - 1) * spacing,
             availY = (contentBox.y2 - contentBox.y1) - totalSpacingY;
 
@@ -788,7 +804,7 @@ const ThumbnailsBox = new Lang.Class({
             indicatorY2,
             indicatorX2,
         // when not animating, the workspace position overrides this._indicatorY
-            indicatorWorkspace = !this._animatingIndicator ? global.screen.get_active_workspace() : null,
+            indicatorWorkspace = !this._animatingIndicator ? Utils.WS.getWS().get_active_workspace() : null,
             indicatorThemeNode = this._indicator.get_theme_node(),
 
             indicatorTopFullBorder = indicatorThemeNode.get_padding(St.Side.TOP) + indicatorThemeNode.get_border_width(St.Side.TOP),
@@ -980,14 +996,14 @@ function overrideWorkspaceDisplay() {
                 // same as the original, but for LEFT/RIGHT
                 // if (!actor.mapped)
                 //     return false;
-                let wsIndex =  global.screen.get_active_workspace_index();
+                let wsIndex =  Utils.WS.getWS().get_active_workspace_index();
 
                 switch (event.get_scroll_direction()) {
                     case Clutter.ScrollDirection.UP:
-                        global.screen.workspace_grid.actionMoveWorkspace(wsIndex-1);
+                        Utils.WS.getWS().workspace_grid.actionMoveWorkspace(wsIndex-1);
                         return Clutter.EVENT_STOP;
                     case Clutter.ScrollDirection.DOWN:
-                        global.screen.workspace_grid.actionMoveWorkspace(wsIndex+1);
+                        Utils.WS.getWS().workspace_grid.actionMoveWorkspace(wsIndex+1);
                         return Clutter.EVENT_STOP;
                 }
 
@@ -1126,15 +1142,15 @@ function disableDynamicWorkspaces() {
 function modifyNumWorkspaces() {
     /// Setting the number of workspaces.
     Meta.prefs_set_num_workspaces(
-        global.screen.workspace_grid.rows * global.screen.workspace_grid.columns
+        Utils.WS.getWS().workspace_grid.rows * Utils.WS.getWS().workspace_grid.columns
     );
 
     /* NOTE: in GNOME 3.4, 3.6, 3.8, Meta.prefs_set_num_workspaces has
      * *no effect* if Meta.prefs_get_dynamic_workspaces is true.
      * (see mutter/src/core/screen.c prefs_changed_callback).
      * To *actually* increase/decrease the number of workspaces (to fire
-     * notify::n-workspaces), we must use global.screen.append_new_workspace and
-     * global.screen.remove_workspace.
+     * notify::n-workspaces), we must use Utils.WS.getWS().append_new_workspace and
+     * Utils.WS.getWS().remove_workspace.
      *
      * We could just set org.gnome.shell.overrides.dynamic-workspaces to false
      * but then we can't drag and drop windows between workspaces (supposedly a
@@ -1145,17 +1161,17 @@ function modifyNumWorkspaces() {
      * drag/drop to create new workspaces (with the placeholder animation),
      * so I'll stick to this method for now.
      */
-    let newtotal = (global.screen.workspace_grid.rows *
-        global.screen.workspace_grid.columns);
-    if (global.screen.n_workspaces < newtotal) {
-        for (let i = global.screen.n_workspaces; i < newtotal; ++i) {
-            global.screen.append_new_workspace(false,
+    let newtotal = (Utils.WS.getWS().workspace_grid.rows *
+        Utils.WS.getWS().workspace_grid.columns);
+    if (Utils.WS.getWS().n_workspaces < newtotal) {
+        for (let i = Utils.WS.getWS().n_workspaces; i < newtotal; ++i) {
+            Utils.WS.getWS().append_new_workspace(false,
                     global.get_current_time());
         }
-    } else if (global.screen.n_workspaces > newtotal) {
-        for (let i = global.screen.n_workspaces - 1; i >= newtotal; --i) {
-            global.screen.remove_workspace(
-                    global.screen.get_workspace_by_index(i),
+    } else if (Utils.WS.getWS().n_workspaces > newtotal) {
+        for (let i = Utils.WS.getWS().n_workspaces - 1; i >= newtotal; --i) {
+            Utils.WS.getWS().remove_workspace(
+                    Utils.WS.getWS().get_workspace_by_index(i),
                     global.get_current_time()
             );
         }
@@ -1163,16 +1179,16 @@ function modifyNumWorkspaces() {
 
     // This affects workspace.get_neighbor() (only exposed in 3.8+) and appears
     // to do not much else. We'll do it anyway just in case.
-    global.screen.override_workspace_layout(
-        Meta.ScreenCorner.TOPLEFT, // workspace 0
+    Utils.WS.getWS().override_workspace_layout(
+        Utils.WS.getCorner().TOPLEFT, // workspace 0
         false, // true == lay out in columns. false == lay out in rows
-        global.screen.workspace_grid.rows,
-        global.screen.workspace_grid.columns
+        Utils.WS.getWS().workspace_grid.rows,
+        Utils.WS.getWS().workspace_grid.columns
     );
 
     // this forces the workspaces display to update itself to match the new
     // number of workspaces.
-    global.screen.notify('n-workspaces');
+    Utils.WS.getWS().notify('n-workspaces');
 
     disableDynamicWorkspaces();
 }
@@ -1181,8 +1197,8 @@ function unmodifyNumWorkspaces() {
     // restore original number of workspaces
     Meta.prefs_set_num_workspaces(nWorkspaces);
 
-    global.screen.override_workspace_layout(
-        Meta.ScreenCorner.TOPLEFT, // workspace 0
+    Utils.WS.getWS().override_workspace_layout(
+        Utils.WS.getCorner().TOPLEFT, // workspace 0
         true, // true == lay out in columns. false == lay out in rows
         nWorkspaces,
         1 // columns
@@ -1191,7 +1207,7 @@ function unmodifyNumWorkspaces() {
 
 /******************
  * Store rows/cols of workspaces, convenience functions to
- * global.screen.workspace_grid
+ * Utils.WS.getWS().workspace_grid
  * such that if other extension authors want to they can use them.
  *
  * Exported constants:
@@ -1200,8 +1216,8 @@ function unmodifyNumWorkspaces() {
  *
  * Exported functions:
  * rowColToIndex : converts the row/column into an index for use with (e.g.)
- *                 global.screen.get_workspace_by_index(i)
- * indexToRowCol : converts an index (0 to global.screen.n_workspaces-1) to a
+ *                 Utils.WS.getWS().get_workspace_by_index(i)
+ * indexToRowCol : converts an index (0 to Utils.WS.getWS().n_workspaces-1) to a
  *                 row and column
  * getWorkspaceSwitcherPopup : gets our workspace switcher popup so you
  *                             can show it if you want
@@ -1211,7 +1227,7 @@ function unmodifyNumWorkspaces() {
  *                 UP, LEFT, RIGHT or DOWN (see Meta.MotionDirection).
  ******************/
 function exportFunctionsAndConstants() {
-    global.screen.workspace_grid = {
+    Utils.WS.getWS().workspace_grid = {
         rows: settings.get_int(KEY_ROWS),
         columns: settings.get_int(KEY_COLS),
 
@@ -1229,13 +1245,13 @@ function exportFunctionsAndConstants() {
             MAX_WORKSPACES) {
         log("WARNING [workspace-grid]: You can have at most 36 workspaces, " +
                 "will ignore the rest");
-        global.screen.workspace_grid.rows = Math.ceil(
-                MAX_WORKSPACES / global.screen.workspace_grid.columns);
+        Utils.WS.getWS().workspace_grid.rows = Math.ceil(
+                MAX_WORKSPACES / Utils.WS.getWS().workspace_grid.columns);
     }
 }
 
 function unexportFunctionsAndConstants() {
-    delete global.screen.workspace_grid;
+    delete Utils.WS.getWS().workspace_grid;
 }
 
 /***************************
@@ -1290,5 +1306,5 @@ function disable() {
 
     // just in case, let everything else get used to the new number of
     // workspaces.
-    global.screen.notify('n-workspaces');
+    Utils.WS.getWS().notify('n-workspaces');
 }

--- a/workspace-grid@mathematical.coffee.gmail.com/metadata.json
+++ b/workspace-grid@mathematical.coffee.gmail.com/metadata.json
@@ -6,7 +6,7 @@
  "gettext-domain": "workspace-grid",
  "description": "Arranges workspaces in a configurable grid.\nAlso:\n* implements keybindings for left/right workspace navigation (up/down are already implemented)\n* updates workspaces sidebar with grid configuration (use Remove Workspaces Sidebar if you don't want it).\n\nYou may also wish to consider instead of/with this extension: Frippery Bottom Panel (already has workspace grid functionality if you want a bottom panel); Frippery Static Workspaces (holds the number of workspaces static and skips all the workspace grid stuff); Remove Workspaces Sidebar; Workspace Indicator Extension (textual indicator/workspace switcher); WorkspaceBar (graphical indicator/workspace switcher); Workspace navigator extension (use arrow keys to navigate workspaces in the Overview).\nSee homepage for more details.",
  "shell-version": [
-     "3.28"
+     "3.30"
  ],
  "url": "https://github.com/zakkak/workspace-grid-gnome-shell-extension",
  "dev-version": "1.5.0",

--- a/workspace-grid@mathematical.coffee.gmail.com/myWorkspaceSwitcherPopup.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/myWorkspaceSwitcherPopup.js
@@ -26,6 +26,7 @@ const Clutter = imports.gi.Clutter;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me             = ExtensionUtils.getCurrentExtension();
 const Prefs          = Me.imports.prefs;
+const Utils          = Me.imports.utils;
 
 const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup;
 
@@ -51,7 +52,7 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
     _getPreferredHeight : function (actor, forWidth, alloc) {
         let children    = this._list.get_children(),
             primary     = Main.layoutManager.primaryMonitor,
-            nrows       = global.screen.workspace_grid.rows,
+            nrows       = Utils.WS.getWS().workspace_grid.rows,
             availHeight = primary.height,
             height      = 0,
             spacing     = this._itemSpacing * (nrows - 1);
@@ -61,8 +62,8 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
         availHeight -= this._container.get_theme_node().get_vertical_padding();
         availHeight -= this._list.get_theme_node().get_vertical_padding();
 
-        for (let i = 0; i < global.screen.n_workspaces;
-                i += global.screen.workspace_grid.columns) {
+        for (let i = 0; i < Utils.WS.getWS().n_workspaces;
+                i += Utils.WS.getWS().workspace_grid.columns) {
             let [childMinHeight, childNaturalHeight] =
                 children[i].get_preferred_height(-1);
             children[i].get_preferred_width(childNaturalHeight);
@@ -93,7 +94,7 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
 
     _getPreferredWidth : function (actor, forHeight, alloc) {
         let primary = Main.layoutManager.primaryMonitor,
-            ncols   = global.screen.workspace_grid.columns;
+            ncols   = Utils.WS.getWS().workspace_grid.columns;
         this._childWidth = this._childHeight * primary.width / primary.height;
         let width   = this._childWidth * ncols + this._itemSpacing * (ncols - 1),
             padding = this.actor.get_theme_node().get_horizontal_padding() +
@@ -121,10 +122,10 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
             prevX    = x,
             prevY    = y,
             i        = 0;
-        for (let row = 0; row < global.screen.workspace_grid.rows; ++row) {
+        for (let row = 0; row < Utils.WS.getWS().workspace_grid.rows; ++row) {
             x     = box.x1;
             prevX = x;
-            for (let col = 0; col < global.screen.workspace_grid.columns; ++col) {
+            for (let col = 0; col < Utils.WS.getWS().workspace_grid.columns; ++col) {
                 childBox.x1 = prevX;
                 childBox.x2 = Math.round(x + this._childWidth);
                 childBox.y1 = prevY;
@@ -144,7 +145,7 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
         //log('redisplay, direction ' + this._direction + ', going to ' + this._activeWorkspaceIndex);
         this._list.destroy_all_children();
 
-        for (let i = 0; i < global.screen.n_workspaces; i++) {
+        for (let i = 0; i < Utils.WS.getWS().n_workspaces; i++) {
             let indicator = null;
             let name = Meta.prefs_get_workspace_name(i);
 
@@ -182,7 +183,7 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
         }
 
         let primary = Main.layoutManager.primaryMonitor;
-        let [containerMinHeight, containerNatHeight] = this._container.get_preferred_height(global.screen_width);
+        let [containerMinHeight, containerNatHeight] = this._container.get_preferred_height(primary.width);
         let [containerMinWidth, containerNatWidth] = this._container.get_preferred_width(containerNatHeight);
         this._container.x = primary.x + Math.floor((primary.width - containerNatWidth) / 2);
         this._container.y = primary.y + Main.panel.actor.height +

--- a/workspace-grid@mathematical.coffee.gmail.com/utils.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/utils.js
@@ -1,0 +1,31 @@
+/***********************************************************************
+ * Copyright (C)      2015 Foivos S. Zakkak <foivos@zakkak.net         *
+ * Copyright (C) 2012-2014 Amy Chan <mathematical.coffee@gmail.com>    *
+ *                                                                     *
+ * This program is free software: you can redistribute it and/or       *
+ * modify it under the terms of the GNU General Public License as      *
+ * published by the Free Software Foundation, either version 3 of the  *
+ * License, or (at your option) any later version.                     *
+ *                                                                     *
+ * This program is distributed in the hope that it will be useful, but *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU   *
+ * General Public License for more details.                            *
+ *                                                                     *
+ * You should have received a copy of the GNU General Public License   *
+ * along with this program.  If not, see                               *
+ * <http://www.gnu.org/licenses/>.                                     *
+ ***********************************************************************/
+
+const Meta = imports.gi.Meta;
+
+// Inspired by https://github.com/micheleg/dash-to-dock/commit/8398d41
+// Maintain compatibility with GNOME-Shell 3.30+ as well as previous versions.
+var WS = {
+    getWS: function() {
+        return global.screen || global.workspace_manager;
+    },
+    getCorner: function() {
+        return Meta.ScreenCorner || Meta.DisplayCorner;
+    }
+};


### PR DESCRIPTION
Hi,

First, thank you for developing and maintaining this very useful extension!

Due to https://gitlab.gnome.org/GNOME/gnome-shell/commit/47ea10b7 the compatibility with 3.30 has been broken. This fix is inspired by this one: https://github.com/micheleg/dash-to-dock/commit/8398d41

- `global.screen` has been replaced by `global.workspace_manager`
- `Meta.ScreenCorner` has been replaced by `Meta.DisplayCorner`
- `Main.wm._showWorkspaceSwitcher` has less arguments (no more `screen`)
- Override schemas are gone (global.get_overrides_settings())

It seems to be originally due to https://gitlab.gnome.org/GNOME/mutter/commit/81c1c70c and https://bugzilla.gnome.org/show_bug.cgi?id=786496

Note: it seems `get_neighbor()` no longer work with `LEFT` / `RIGHT` direction because a right-click on a Window no longer proposes to move it to the right/left as well → https://gitlab.gnome.org/GNOME/mutter/issues/270