### PR TITLE
More control over mouse scroll behaviour

### DIFF
--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -155,6 +155,7 @@ const KEY_ROWS = Prefs.KEY_ROWS;
 const KEY_COLS = Prefs.KEY_COLS;
 const KEY_WRAPAROUND = Prefs.KEY_WRAPAROUND;
 const KEY_WRAP_TO_SAME = Prefs.KEY_WRAP_TO_SAME;
+const KEY_WRAP_TO_SAME_SCROLL = Prefs.KEY_WRAP_TO_SAME_SCROLL;
 const KEY_MAX_HFRACTION = Prefs.KEY_MAX_HFRACTION;
 const KEY_MAX_HFRACTION_COLLAPSE = Prefs.KEY_MAX_HFRACTION_COLLAPSE;
 const KEY_SHOW_WORKSPACE_LABELS = Prefs.KEY_SHOW_WORKSPACE_LABELS;
@@ -268,9 +269,13 @@ function calculateScrollDirection(direction, scrollDirection) {
 }
 
 // calculates the workspace index in that direction.
-function calculateWorkspace(direction, wraparound, wrapToSame, overrideScrollDirection) {
-    if (overrideScrollDirection)
+function calculateWorkspace(direction, wraparound, wrapToSame, wrapToSameScroll, overrideScrollDirection) {
+    if (overrideScrollDirection) {
         direction = calculateScrollDirection(direction, settings.get_string(KEY_SCROLL_DIRECTION));
+        if (!wrapToSameScroll)
+            wrapToSame = wrapToSameScroll;
+   }
+
 
     let from = global.screen.get_active_workspace(),
         to = from.get_neighbor(direction).index();
@@ -422,6 +427,7 @@ function actionMoveWorkspace(destination, overrideScrollDirection = true) {
         to = calculateWorkspace(destination,
                                 settings.get_boolean(KEY_WRAPAROUND),
                                 settings.get_boolean(KEY_WRAP_TO_SAME),
+                                settings.get_boolean(KEY_WRAP_TO_SAME_SCROLL),
                                 overrideScrollDirection);
 
     let ws = global.screen.get_workspace_by_index(to);

--- a/workspace-grid@mathematical.coffee.gmail.com/prefs.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/prefs.js
@@ -45,6 +45,7 @@ var KEY_MAX_HFRACTION = 'max-screen-fraction';
 var KEY_MAX_HFRACTION_COLLAPSE = 'max-screen-fraction-before-collapse';
 var KEY_SHOW_WORKSPACE_LABELS = 'show-workspace-labels';
 var KEY_RELATIVE_WORKSPACE_SWITCHING ="relative-workspace-switching";
+var KEY_SCROLL_DIRECTION = 'scroll-direction';
 
 function init() {
     Convenience.initTranslations();
@@ -111,6 +112,49 @@ const WorkspaceGridPrefsWidget = new GObject.Class({
                 0, 1, 0.05);
         this.addScale(_("Maximum width (fraction) before collapse:"),
                 KEY_MAX_HFRACTION_COLLAPSE, false, 0, 1, 0.05);
+
+
+        this._listStore = new Gtk.ListStore();
+        this._listStore.set_column_types ([
+            GObject.TYPE_STRING,
+            GObject.TYPE_STRING]);
+
+        let options = [
+            { name: "Horizontal", value: "horizontal"  },
+            { name: "Vertical", value: "vertical" }];
+        let defaultOption = 0;
+
+        for (let i = 0; i < options.length; i++ ) {
+            let option = options[i];
+            let iter = this._listStore.append();
+            this._listStore.set (iter, [0], [option.name]);
+            if ('value' in option) {
+                this._listStore.set (iter, [1], [option.value]);
+                if (option.value === this._settings.get_string(KEY_SCROLL_DIRECTION))
+                    defaultOption = i;
+            }
+        }
+
+      this._comboBox = new Gtk.ComboBox({
+          model: this._listStore});
+      item = this._comboBox;
+
+      item.set_active(defaultOption);
+
+      item.connect('changed', Lang.bind(this, function () {
+        let activeItem = this._comboBox.get_active();
+        this._settings.set_string(KEY_SCROLL_DIRECTION, options[activeItem].value)
+      }));
+
+      let rendererText = new Gtk.CellRendererText();
+
+      item.pack_start (rendererText, false);
+
+      item.add_attribute (rendererText, "text", 0);
+
+      this.addRow("Scroll Direction:", item);
+
+
     },
 
     addBoolean: function (text, key) {

--- a/workspace-grid@mathematical.coffee.gmail.com/prefs.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/prefs.js
@@ -108,6 +108,10 @@ const WorkspaceGridPrefsWidget = new GObject.Class({
         this.addBoolean(_("Show workspace labels in the switcher?"),
             KEY_SHOW_WORKSPACE_LABELS);
 
+        this.addTextComboBox("Scroll Direction: ", KEY_SCROLL_DIRECTION,
+            [ { name: "Horizontal", value: "horizontal"},
+              { name: "Vertical", value: "vertical" } ]);
+
         item = new Gtk.Label({
             label: _("The following settings determine how much horizontal " +
                     "space the workspaces box\n in the overview can take up, " +
@@ -120,49 +124,6 @@ const WorkspaceGridPrefsWidget = new GObject.Class({
                 0, 1, 0.05);
         this.addScale(_("Maximum width (fraction) before collapse:"),
                 KEY_MAX_HFRACTION_COLLAPSE, false, 0, 1, 0.05);
-
-
-        this._listStore = new Gtk.ListStore();
-        this._listStore.set_column_types ([
-            GObject.TYPE_STRING,
-            GObject.TYPE_STRING]);
-
-        let options = [
-            { name: "Horizontal", value: "horizontal"  },
-            { name: "Vertical", value: "vertical" }];
-        let defaultOption = 0;
-
-        for (let i = 0; i < options.length; i++ ) {
-            let option = options[i];
-            let iter = this._listStore.append();
-            this._listStore.set (iter, [0], [option.name]);
-            if ('value' in option) {
-                this._listStore.set (iter, [1], [option.value]);
-                if (option.value === this._settings.get_string(KEY_SCROLL_DIRECTION))
-                    defaultOption = i;
-            }
-        }
-
-      this._comboBox = new Gtk.ComboBox({
-          model: this._listStore});
-      item = this._comboBox;
-
-      item.set_active(defaultOption);
-
-      item.connect('changed', Lang.bind(this, function () {
-        let activeItem = this._comboBox.get_active();
-        this._settings.set_string(KEY_SCROLL_DIRECTION, options[activeItem].value)
-      }));
-
-      let rendererText = new Gtk.CellRendererText();
-
-      item.pack_start (rendererText, false);
-
-      item.add_attribute (rendererText, "text", 0);
-
-      this.addRow("Scroll Direction:", item);
-
-
     },
 
     addBoolean: function (text, key) {
@@ -264,6 +225,24 @@ const WorkspaceGridPrefsWidget = new GObject.Class({
             }));
         }
         return this.addRow(text, hscale, true);
+    },
+
+    addTextComboBox: function (text, key, options) {
+      let item = new Gtk.ComboBoxText();
+
+      for (let i = 0; i < options.length; i++ ) {
+        item.append_text(options[i].name);
+        if (options[i].value === this._settings.get_string(key))
+              activeOption = i;
+      }
+      item.set_active(activeOption);
+
+      item.connect('changed', Lang.bind(this, function () {
+        let activeItem = item.get_active();
+        this._settings.set_string(key, options[activeItem].value);
+      }));
+
+      return this.addRow(text, item);
     },
 
     addItem: function (widget, col, colspan, rowspan) {

--- a/workspace-grid@mathematical.coffee.gmail.com/prefs.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/prefs.js
@@ -41,6 +41,7 @@ var KEY_ROWS = 'num-rows';
 var KEY_COLS = 'num-columns';
 var KEY_WRAPAROUND = 'wraparound';
 var KEY_WRAP_TO_SAME = 'wrap-to-same';
+var KEY_WRAP_TO_SAME_SCROLL = 'wrap-to-same-scroll';
 var KEY_MAX_HFRACTION = 'max-screen-fraction';
 var KEY_MAX_HFRACTION_COLLAPSE = 'max-screen-fraction-before-collapse';
 var KEY_SHOW_WORKSPACE_LABELS = 'show-workspace-labels';
@@ -93,8 +94,15 @@ const WorkspaceGridPrefsWidget = new GObject.Class({
         this._sameRowCol = this.addBoolean(
             _(" ... and wrap to the same row/col (as opposed to the next/previous)?"),
             KEY_WRAP_TO_SAME);
+        this._sameRowColScroll = this.addBoolean(
+            _("     ... wrap to same also for mouse scrolling?"),
+            KEY_WRAP_TO_SAME_SCROLL);
+        this._sameRowColScroll.set_sensitive(this._sameRowCol.active);
         toggle.connect('notify::active', Lang.bind(this, function(widget) {
             this._sameRowCol.set_sensitive(widget.active);
+        }));
+        this._sameRowCol.connect('notify::active', Lang.bind(this, function(widget) {
+            this._sameRowColScroll.set_sensitive(widget.active);
         }));
 
         this.addBoolean(_("Show workspace labels in the switcher?"),

--- a/workspace-grid@mathematical.coffee.gmail.com/schemas/org.gnome.shell.extensions.workspace-grid.gschema.xml
+++ b/workspace-grid@mathematical.coffee.gmail.com/schemas/org.gnome.shell.extensions.workspace-grid.gschema.xml
@@ -45,6 +45,11 @@
       <summary>Maximum fraction of the screen workspace thumbnails may take up before collapsing in the overview.</summary>
       <description>Maximum (horizontal) fraction of the screen the workspace thumbnails are allowed to take up in the overview before the workspace thumbnail box intialised collapsed (hover to open).</description>
     </key>
+    <key type="s" name="scroll-direction">
+      <default>"horizontal"</default>
+      <summary>The direction that scroll event follows</summary>
+      <description>The direction that scroll event follows.</description>
+    </key>
 
   </schema>
 </schemalist>

--- a/workspace-grid@mathematical.coffee.gmail.com/schemas/org.gnome.shell.extensions.workspace-grid.gschema.xml
+++ b/workspace-grid@mathematical.coffee.gmail.com/schemas/org.gnome.shell.extensions.workspace-grid.gschema.xml
@@ -28,6 +28,11 @@
       <summary>Whether to wrap to the *same* row/col or the next/previous one if wraparound is enabled.</summary>
       <description>If the wraparound setting is enabled, should we wrap to the *same* row/col or the next/previous row/col when we wrap? E.g. if we are trying to navigate right from the top-right-most workspace, do we wrap the the leftmost workspace on the same row, or the leftmost workspace on the next row?</description>
     </key>
+    <key type="b" name="wrap-to-same-scroll">
+      <default>false</default>
+      <summary>Whether to wrap to the *same* row/col or the next/previous on scrolling one if warp-to-same is enabled.</summary>
+      <description>If the warp-to-same setting is enabled, should we wrap to the *same* row/col or the next/previous row/col during scrolling when we wrap? E.g. if we are trying to navigate right from the top-right-most workspace, do we wrap the the leftmost workspace on the same row, or the leftmost workspace on the next row?</description>
+    </key>
     <key type="b" name="show-workspace-labels">
       <default>true</default>
       <summary>Whether to show workspace names in the workspace switcher popup</summary>


### PR DESCRIPTION
In this PR added a option to choose if the mouse scroll events will swipe the workspace _horizontaly_ or _verticaly_.
This also keep the *actionMoveWorkspace(int)* exported function working for further integrations with other extensions.