### PR TITLE
Support 3.29.90 get neighbor workaround

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -93,16 +93,17 @@ these are things you need to know.
 
 ** Exported stuff
 
-   This extension exports a number of constants and functions to an
-   object ~global.screen.workspace_grid~ for your convenience.  (It
-   isn't particularly good code style as this "breaks the extension
+   This extension exports a number of constants and functions to an object
+   global.screen.workspace_grid (GNOME <= 3.28) or global.workspace_manager
+   (GNOME > 3.28) for your convenience.
+   (It isn't particularly good code style as this "breaks the extension
    barrier" so to speak - extensions are meant to be standalone and
    modular, but when multiple extensions have overlapping
    functionalities it makes sense to use another extension's
    functionality rather than re-implement it in your own).
 
    Note that the Workspace Grid extension must be enabled for this all to
-   work.  The ~global.screen.workspace_grid~ object contains:
+   work. The ~global.{screen,workspace_manager}.workspace_grid~ object contains:
 
    (Exported Constants)
 
@@ -118,9 +119,9 @@ these are things you need to know.
      being either (~Directions.~)~UP~, ~LEFT~, ~RIGHT~ or ~DOWN~ (see
      ~Directions~).
    - ~rowColToIndex~ : converts the row/column into an index for use
-     with (e.g.) ~global.screen.get_workspace_by_index(i)~
+     with (e.g.) ~global.{screen,workspace_manager}.get_workspace_by_index(i)~
    - ~indexToRowCol~ : converts an index (~0 to
-     global.screen.n_workspaces-1~) to a row and column
+     global.{screen,workspace_manager}.n_workspaces-1~) to a row and column
    - ~calculateWorkspace~ : calculates the index of the workspace
      adjacent in the specified direction to the current one.
    - ~getWorkspaceSwitcherPopup~ : retrieves our workspace switcher
@@ -130,25 +131,25 @@ these are things you need to know.
    For example, to move to the workspace below us:
 
 #+BEGIN_EXAMPLE
-    const WorkspaceGrid = global.screen.workspace_grid;
+    const WorkspaceGrid = global.{screen,workspace_manager}.workspace_grid;
     WorkspaceGrid.moveWorkspace(WorkspaceGrid.Directions.DOWN);
 #+END_EXAMPLE
 
 ** Listening to Workspace Grid
    Say you want to know the number of rows/columns of workspaces in
    your extension. Then you have to wait for this extension to load
-   and populate ~global.screen.workspace_grid~.
+   and populate ~global.{screen,workspace_manager}.workspace_grid~.
 
    When the Workspace Grid extension enables or disables it fires a
-   ~'notify::n_workspaces'~ signal on global.screen.  You can connect
-   to this and check for the existence (or removal) of
-   ~global.screen.workspace_grid~.
+   ~'notify::n_workspaces'~ signal on global.{screen,workspace_manager}.
+   You can connect to this and check for the existence (or removal) of
+   ~global.{screen,workspace_manager}.workspace_grid~.
 
    e.g.:
 
 #+BEGIN_EXAMPLE
-    let ID = global.screen.connect('notify::n-workspaces', function () {
-        if (global.screen.workspace_grid) {
+    let ID = global.workspace_manager.connect('notify::n-workspaces', function () {
+        if (global.workspace_manager.workspace_grid) {
             // then we can use workspace_grid.rows, cols, etc
         } else {
             // remember, your extension should be able to handle this one being

--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -259,6 +259,31 @@ function getWorkspaceSwitcherPopup() {
     return Main.wm._workspaceSwitcherPopup;
 }
 
+/* Same as: from.get_neighbor(direction).index();
+ * Workaround for GNOME 3.29.90.
+ * Bug report: https://gitlab.gnome.org/GNOME/mutter/issues/270
+ */
+function get_neighbor(direction, from) {
+    let [row, col] = indexToRowCol(from.index());
+
+    switch (direction) {
+        case LEFT:
+            col = Math.max(0, col - 1);
+            break;
+        case RIGHT:
+            col = Math.min(Utils.WS.getWS().workspace_grid.columns - 1, col + 1);
+            break;
+        case UP:
+            row = Math.max(0, row - 1);
+            break;
+        case DOWN:
+            row = Math.min(Utils.WS.getWS().workspace_grid.rows - 1, row + 1);
+            break;
+    }
+
+    return rowColToIndex(row, col);
+}
+
 function calculateScrollDirection(direction, scrollDirection) {
   if (scrollDirection === 'horizontal') {
     switch (direction) {
@@ -283,7 +308,7 @@ function calculateWorkspace(direction, wraparound, wrapToSame, wrapToSameScroll,
 
 
     let from = Utils.WS.getWS().get_active_workspace(),
-        to = from.get_neighbor(direction).index();
+        to = get_neighbor(direction, from);
 
     if (!wraparound || from.index() !== to) {
         return to;

--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -1187,7 +1187,13 @@ function unoverrideWorkspaceDisplay() {
 * Sets org.gnome.shell.overrides.dynamic-workspaces schema to false
 *******************/
 function disableDynamicWorkspaces() {
-    let settings = global.get_overrides_settings();
+    let settings;
+    // Override schemas are gone in GNOME 3.30
+    if (Utils.isVersionAbove(3, 28)) {
+        settings = new Gio.Settings({ schema_id: 'org.gnome.mutter' });
+    } else {
+        settings = global.get_overrides_settings()
+    }
     settings.set_boolean('dynamic-workspaces', false);
 }
 

--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -31,8 +31,10 @@
  * If you wish to see if your extension is compatible with this, note:
  *
  * This extension exports a number of constants and functions to an object
- * global.screen.workspace_grid for your convenience. Note that this extension
- * must be enabled for this all to work. global.screen.workspace_grid contains:
+ * global.screen.workspace_grid (GNOME <= 3.28) or global.workspace_manager
+ * (GNOME > 3.28) for your convenience. Note that this extension must be enabled
+ * for this all to work.
+ * global.{screen,workspace_manager}.workspace_grid contains:
  *
  *   (Exported Constants)
  *   - rows     : number of rows of workspaces
@@ -42,16 +44,17 @@
  *   - moveWorkspace : switches workspaces in the direction specified, being
  *                     either UP, LEFT, RIGHT or DOWN (see Meta.MotionDirection).
  *   - rowColToIndex : converts the row/column into an index for use with (e.g.)
- *                     global.screen.get_workspace_by_index(i)
- *   - indexToRowCol : converts an index (0 to global.screen.n_workspaces-1) to
- *                     a row and column
+ *                     global.{screen,workspace_manager}.get_workspace_by_index(i)
+ *   - indexToRowCol : converts an index (0 to
+ *                     global.{screen,workspace_manager}.n_workspaces-1) to a
+ *                     row and column
  *   - getWorkspaceSwitcherPopup : gets our workspace switcher popup so you
  *                                 can show it if you want
  *   - calculateWorkspace : returns the workspace index in the specified direction
  *                          to the current, taking into account wrapping.
  *
  * For example, to move to the workspace below us:
- *     const WorkspaceGrid = global.screen.workspace_grid;
+ *     const WorkspaceGrid = global.{screen,workspace_manager}.workspace_grid;
  *     WorkspaceGrid.moveWorkspace(Meta.MotionDirection.DOWN);
  *
  * I am happy to try help/give an opinion/improve this extension to try make it
@@ -61,13 +64,13 @@
  * ---------------------------
  * Say you want to know the number of rows/columns of workspaces in your
  * extension. Then you have to wait for this extension to load and populate
- * global.screen.workspace_grid.
+ * global.{screen,workspace_manager}.workspace_grid.
  *
  * When the workspace_grid extension enables or disables it fires a
- *  'notify::n_workspaces' signal on global.screen.
+ *  'notify::n_workspaces' signal on global.{screen,workspace_manager}.
  *
  * You can connect to this and check for the existence (or removal) of
- * global.screen.workspace_grid.
+ * global.{screen,workspace_manager}.workspace_grid.
  *
  * Further notes
  * -------------
@@ -150,6 +153,7 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 const Prefs = Me.imports.prefs;
 const MyWorkspaceSwitcherPopup = Me.imports.myWorkspaceSwitcherPopup;
+const Utils = Me.imports.utils;
 
 const KEY_ROWS = Prefs.KEY_ROWS;
 const KEY_COLS = Prefs.KEY_COLS;
@@ -214,15 +218,16 @@ let settings = 0;
 /***************
  * Helper functions
  ***************/
-/* Converts an index (from 0 to global.screen.n_workspaces) into [row, column]
- * being the row and column of workspace `index` according to the user's layout.
+/* Converts an index (from 0 to global.{screen,workspace_manager}.n_workspaces)
+ * into [row, column] being the row and column of workspace `index` according to
+ * the user's layout.
  *
  * Row and column start from 0.
  */
 function indexToRowCol(index) {
     // row-major. 0-based.
-    return [Math.floor(index / global.screen.workspace_grid.columns),
-       index % global.screen.workspace_grid.columns];
+    return [Math.floor(index / Utils.WS.getWS().workspace_grid.columns),
+       index % Utils.WS.getWS().workspace_grid.columns];
 }
 
 /* Converts a row and column (0-based) into the index of that workspace.
@@ -232,7 +237,7 @@ function indexToRowCol(index) {
  */
 function rowColToIndex(row, col) {
     // row-major. 0-based.
-    let idx = row * global.screen.workspace_grid.columns + col;
+    let idx = row * Utils.WS.getWS().workspace_grid.columns + col;
     if (idx >= MAX_WORKSPACES) {
         idx = -1;
     }
@@ -277,7 +282,7 @@ function calculateWorkspace(direction, wraparound, wrapToSame, wrapToSameScroll,
    }
 
 
-    let from = global.screen.get_active_workspace(),
+    let from = Utils.WS.getWS().get_active_workspace(),
         to = from.get_neighbor(direction).index();
 
     if (!wraparound || from.index() !== to) {
@@ -289,7 +294,7 @@ function calculateWorkspace(direction, wraparound, wrapToSame, wrapToSameScroll,
     switch (direction) {
         case LEFT:
             // we must be at the start of the row. go to the end of the row.
-            col = global.screen.workspace_grid.columns - 1;
+            col = Utils.WS.getWS().workspace_grid.columns - 1;
             if (!wrapToSame) row--;
             break;
         case RIGHT:
@@ -299,7 +304,7 @@ function calculateWorkspace(direction, wraparound, wrapToSame, wrapToSameScroll,
             break;
         case UP:
             // we must be at the top of the col. go to the bottom of the same col.
-            row = global.screen.workspace_grid.rows - 1;
+            row = Utils.WS.getWS().workspace_grid.rows - 1;
             if (!wrapToSame) col--;
             break;
         case DOWN:
@@ -309,9 +314,9 @@ function calculateWorkspace(direction, wraparound, wrapToSame, wrapToSameScroll,
             break;
     }
     if (col < 0 || row < 0) {
-        to = global.screen.n_workspaces - 1;
-    } else if (col > global.screen.workspace_grid.columns - 1 ||
-               row > global.screen.workspace_grid.rows - 1) {
+        to = Utils.WS.getWS().n_workspaces - 1;
+    } else if (col > Utils.WS.getWS().workspace_grid.columns - 1 ||
+               row > Utils.WS.getWS().workspace_grid.rows - 1) {
         to = 0;
     } else {
         to = rowColToIndex(row, col);
@@ -355,11 +360,25 @@ function moveWorkspace(direction) {
  * This is the same as WindowManager._showWorkspaceSwitcher but we don't
  * filter out RIGHT/LEFT actions like they do.
  */
-function showWorkspaceSwitcher(display, screen, window, binding) {
+function showWorkspaceSwitcher(display, arg2, arg3, arg4) {
+    let screen;
+    let window;
+    let binding;
+    // Note: in v3.30, the 2nd arg (screen that we don't need) has been removed
+    if (Utils.isVersionAbove(3, 28)) {
+        screen = display.get_workspace_manager();
+        window = arg2;
+        binding = arg3;
+    } else {
+        screen = arg2;
+        window = arg3;
+        binding = arg4;
+    }
+
     if (!Main.sessionMode.hasWorkspaces)
         return;
 
-    if (global.screen.n_workspaces === 1)
+    if (Utils.WS.getWS().n_workspaces === 1)
         return;
 
     let [action,,,target] = binding.get_name().split('-');
@@ -388,9 +407,9 @@ function showWorkspaceSwitcher(display, screen, window, binding) {
         direction = Meta.MotionDirection[target.toUpperCase()];
     } else if (target > 0) {
         target--;
-		if (settings.get_boolean(Prefs.KEY_RELATIVE_WORKSPACE_SWITCHING)) {
-			target = target + Math.floor(screen.get_active_workspace_index() / global.screen.workspace_grid.columns ) * global.screen.workspace_grid.columns ;
-		}
+        if (settings.get_boolean(Prefs.KEY_RELATIVE_WORKSPACE_SWITCHING)) {
+            target = target + Math.floor(screen.get_active_workspace_index() / Utils.WS.getWS().workspace_grid.columns) * Utils.WS.getWS().workspace_grid.columns ;
+        }
         newWs = screen.get_workspace_by_index(target);
     }
 
@@ -417,7 +436,7 @@ function showWorkspaceSwitcher(display, screen, window, binding) {
 }
 
 function actionMoveWorkspace(destination, overrideScrollDirection = true) {
-    let from = global.screen.get_active_workspace_index();
+    let from = Utils.WS.getWS().get_active_workspace_index();
 
     let to;
     // destination >= 0 is workspace index, otherwise its a direction
@@ -430,11 +449,11 @@ function actionMoveWorkspace(destination, overrideScrollDirection = true) {
                                 settings.get_boolean(KEY_WRAP_TO_SAME_SCROLL),
                                 overrideScrollDirection);
 
-    let ws = global.screen.get_workspace_by_index(to);
+    let ws = Utils.WS.getWS().get_workspace_by_index(to);
 
     // if ws is null, the workspace does't exist, so keep on actual workspace
     if (ws == null) {
-        ws = global.screen.get_active_workspace();
+        ws = Utils.WS.getWS().get_active_workspace();
     }
 
     if (to !== from) {
@@ -453,9 +472,9 @@ function actionMoveWindow(window, destination) {
                                 settings.get_boolean(KEY_WRAPAROUND),
                                 settings.get_boolean(KEY_WRAP_TO_SAME));
 
-    let ws = global.screen.get_workspace_by_index(to);
+    let ws = Utils.WS.getWS().get_workspace_by_index(to);
 
-    if (to !== global.screen.get_active_workspace_index()) {
+    if (to !== Utils.WS.getWS().get_active_workspace_index()) {
         Main.wm._movingWindow = window;
         window.change_workspace(ws);
         global.display.clear_mouse_mode();
@@ -675,7 +694,7 @@ const ThumbnailsBox = new Lang.Class({
 
     _activeWorkspaceChanged: function () {
         let thumbnail;
-        let activeWorkspace = global.screen.get_active_workspace();
+        let activeWorkspace = Utils.WS.getWS().get_active_workspace();
         for (let i = 0; i < this._thumbnails.length; i++) {
             if (this._thumbnails[i].metaWorkspace === activeWorkspace) {
                 thumbnail = this._thumbnails[i];
@@ -706,7 +725,7 @@ const ThumbnailsBox = new Lang.Class({
         let themeNode    = this.actor.get_theme_node();
 
         let spacing      = themeNode.get_length('spacing');
-        let nWorkspaces  = global.screen.workspace_grid.rows;
+        let nWorkspaces  = Utils.WS.getWS().workspace_grid.rows;
         let totalSpacing = (nWorkspaces - 1) * spacing;
 
         alloc.min_size     = totalSpacing;
@@ -728,8 +747,8 @@ const ThumbnailsBox = new Lang.Class({
 
         let themeNode = this.actor.get_theme_node(),
             spacing = this.actor.get_theme_node().get_length('spacing'),
-            nRows = global.screen.workspace_grid.rows,
-            nCols = global.screen.workspace_grid.columns,
+            nRows = Utils.WS.getWS().workspace_grid.rows,
+            nCols = Utils.WS.getWS().workspace_grid.columns,
             totalSpacingX = (nCols - 1) * spacing,
             totalSpacingY = (nRows - 1) * spacing,
             availY = forHeight - totalSpacingY,
@@ -770,8 +789,8 @@ const ThumbnailsBox = new Lang.Class({
         let spacing = this.actor.get_theme_node().get_length('spacing');
 
         // Compute the scale we'll need once everything is updated
-        let nCols = global.screen.workspace_grid.columns,
-            nRows = global.screen.workspace_grid.rows,
+        let nCols = Utils.WS.getWS().workspace_grid.columns,
+            nRows = Utils.WS.getWS().workspace_grid.rows,
             totalSpacingY = (nRows - 1) * spacing,
             availY = (contentBox.y2 - contentBox.y1) - totalSpacingY;
 
@@ -822,7 +841,7 @@ const ThumbnailsBox = new Lang.Class({
             indicatorY2,
             indicatorX2,
         // when not animating, the workspace position overrides this._indicatorY
-            indicatorWorkspace = !this._animatingIndicator ? global.screen.get_active_workspace() : null,
+            indicatorWorkspace = !this._animatingIndicator ? Utils.WS.getWS().get_active_workspace() : null,
             indicatorThemeNode = this._indicator.get_theme_node(),
 
             indicatorTopFullBorder = indicatorThemeNode.get_padding(St.Side.TOP) + indicatorThemeNode.get_border_width(St.Side.TOP),
@@ -1014,7 +1033,7 @@ function overrideWorkspaceDisplay() {
         /* FelipeMarinho97 - <felipevm97@gmail.com>:
          *
          * This function **_scrollHandler**, uses a exported function
-         * global.screen.workspace_grid.actionMoveWorkspace.
+         * global.{screen,workspace_manager}.workspace_grid.actionMoveWorkspace.
          * For controlling scroll-direction, we have two options:
          *   1 - create two different handlers and choose the right one according
          * to the value of the "scroll-direction" option.
@@ -1032,14 +1051,14 @@ function overrideWorkspaceDisplay() {
          */
         function _scrollHandler (actor, event) {
             // same as the original, but for TOP/DOWN on grid
-            let wsIndex = global.screen.get_active_workspace_index();
+            let wsIndex =  Utils.WS.getWS().get_active_workspace_index();
 
             switch (event.get_scroll_direction()) {
                 case Clutter.ScrollDirection.UP:
-                    global.screen.workspace_grid.actionMoveWorkspace(Meta.MotionDirection.UP);
+                    Utils.WS.getWS().workspace_grid.actionMoveWorkspace(Meta.MotionDirection.UP);
                     return Clutter.EVENT_STOP;
                 case Clutter.ScrollDirection.DOWN:
-                    global.screen.workspace_grid.actionMoveWorkspace(Meta.MotionDirection.DOWN);
+                    Utils.WS.getWS().workspace_grid.actionMoveWorkspace(Meta.MotionDirection.DOWN);
                     return Clutter.EVENT_STOP;
             }
 
@@ -1178,15 +1197,15 @@ function disableDynamicWorkspaces() {
 function modifyNumWorkspaces() {
     /// Setting the number of workspaces.
     Meta.prefs_set_num_workspaces(
-        global.screen.workspace_grid.rows * global.screen.workspace_grid.columns
+        Utils.WS.getWS().workspace_grid.rows * Utils.WS.getWS().workspace_grid.columns
     );
 
     /* NOTE: in GNOME 3.4, 3.6, 3.8, Meta.prefs_set_num_workspaces has
      * *no effect* if Meta.prefs_get_dynamic_workspaces is true.
      * (see mutter/src/core/screen.c prefs_changed_callback).
      * To *actually* increase/decrease the number of workspaces (to fire
-     * notify::n-workspaces), we must use global.screen.append_new_workspace and
-     * global.screen.remove_workspace.
+     * notify::n-workspaces), we must use Utils.WS.getWS().append_new_workspace
+     * and Utils.WS.getWS().remove_workspace.
      *
      * We could just set org.gnome.shell.overrides.dynamic-workspaces to false
      * but then we can't drag and drop windows between workspaces (supposedly a
@@ -1197,17 +1216,17 @@ function modifyNumWorkspaces() {
      * drag/drop to create new workspaces (with the placeholder animation),
      * so I'll stick to this method for now.
      */
-    let newtotal = (global.screen.workspace_grid.rows *
-        global.screen.workspace_grid.columns);
-    if (global.screen.n_workspaces < newtotal) {
-        for (let i = global.screen.n_workspaces; i < newtotal; ++i) {
-            global.screen.append_new_workspace(false,
+    let newtotal = (Utils.WS.getWS().workspace_grid.rows *
+        Utils.WS.getWS().workspace_grid.columns);
+    if (Utils.WS.getWS().n_workspaces < newtotal) {
+        for (let i = Utils.WS.getWS().n_workspaces; i < newtotal; ++i) {
+            Utils.WS.getWS().append_new_workspace(false,
                     global.get_current_time());
         }
-    } else if (global.screen.n_workspaces > newtotal) {
-        for (let i = global.screen.n_workspaces - 1; i >= newtotal; --i) {
-            global.screen.remove_workspace(
-                    global.screen.get_workspace_by_index(i),
+    } else if (Utils.WS.getWS().n_workspaces > newtotal) {
+        for (let i = Utils.WS.getWS().n_workspaces - 1; i >= newtotal; --i) {
+            Utils.WS.getWS().remove_workspace(
+                    Utils.WS.getWS().get_workspace_by_index(i),
                     global.get_current_time()
             );
         }
@@ -1215,16 +1234,16 @@ function modifyNumWorkspaces() {
 
     // This affects workspace.get_neighbor() (only exposed in 3.8+) and appears
     // to do not much else. We'll do it anyway just in case.
-    global.screen.override_workspace_layout(
-        Meta.ScreenCorner.TOPLEFT, // workspace 0
+    Utils.WS.getWS().override_workspace_layout(
+        Utils.WS.getCorner().TOPLEFT, // workspace 0
         false, // true == lay out in columns. false == lay out in rows
-        global.screen.workspace_grid.rows,
-        global.screen.workspace_grid.columns
+        Utils.WS.getWS().workspace_grid.rows,
+        Utils.WS.getWS().workspace_grid.columns
     );
 
     // this forces the workspaces display to update itself to match the new
     // number of workspaces.
-    global.screen.notify('n-workspaces');
+    Utils.WS.getWS().notify('n-workspaces');
 
     disableDynamicWorkspaces();
 }
@@ -1233,8 +1252,8 @@ function unmodifyNumWorkspaces() {
     // restore original number of workspaces
     Meta.prefs_set_num_workspaces(nWorkspaces);
 
-    global.screen.override_workspace_layout(
-        Meta.ScreenCorner.TOPLEFT, // workspace 0
+    Utils.WS.getWS().override_workspace_layout(
+        Utils.WS.getCorner().TOPLEFT, // workspace 0
         true, // true == lay out in columns. false == lay out in rows
         nWorkspaces,
         1 // columns
@@ -1243,7 +1262,7 @@ function unmodifyNumWorkspaces() {
 
 /******************
  * Store rows/cols of workspaces, convenience functions to
- * global.screen.workspace_grid
+ * global.{screen,workspace_manager}.workspace_grid
  * such that if other extension authors want to they can use them.
  *
  * Exported constants:
@@ -1252,9 +1271,10 @@ function unmodifyNumWorkspaces() {
  *
  * Exported functions:
  * rowColToIndex : converts the row/column into an index for use with (e.g.)
- *                 global.screen.get_workspace_by_index(i)
- * indexToRowCol : converts an index (0 to global.screen.n_workspaces-1) to a
- *                 row and column
+ *                 global.{screen,workspace_manager}.get_workspace_by_index(i)
+ * indexToRowCol : converts an index (0 to
+ *                 global.{screen,workspace_manager}.n_workspaces-1) to a row
+ *                 and column
  * getWorkspaceSwitcherPopup : gets our workspace switcher popup so you
  *                             can show it if you want
  * calculateWorkspace : returns the workspace index in the specified direction
@@ -1263,7 +1283,7 @@ function unmodifyNumWorkspaces() {
  *                 UP, LEFT, RIGHT or DOWN (see Meta.MotionDirection).
  ******************/
 function exportFunctionsAndConstants() {
-    global.screen.workspace_grid = {
+    Utils.WS.getWS().workspace_grid = {
         rows: settings.get_int(KEY_ROWS),
         columns: settings.get_int(KEY_COLS),
 
@@ -1281,13 +1301,13 @@ function exportFunctionsAndConstants() {
             MAX_WORKSPACES) {
         log("WARNING [workspace-grid]: You can have at most 36 workspaces, " +
                 "will ignore the rest");
-        global.screen.workspace_grid.rows = Math.ceil(
-                MAX_WORKSPACES / global.screen.workspace_grid.columns);
+        Utils.WS.getWS().workspace_grid.rows = Math.ceil(
+                MAX_WORKSPACES / Utils.WS.getWS().workspace_grid.columns);
     }
 }
 
 function unexportFunctionsAndConstants() {
-    delete global.screen.workspace_grid;
+    delete Utils.WS.getWS().workspace_grid;
 }
 
 /***************************
@@ -1342,5 +1362,5 @@ function disable() {
 
     // just in case, let everything else get used to the new number of
     // workspaces.
-    global.screen.notify('n-workspaces');
+    Utils.WS.getWS().notify('n-workspaces');
 }

--- a/workspace-grid@mathematical.coffee.gmail.com/metadata.json
+++ b/workspace-grid@mathematical.coffee.gmail.com/metadata.json
@@ -6,7 +6,7 @@
  "gettext-domain": "workspace-grid",
  "description": "Arranges workspaces in a configurable grid.\nAlso:\n* implements keybindings for left/right workspace navigation (up/down are already implemented)\n* updates workspaces sidebar with grid configuration (use Remove Workspaces Sidebar if you don't want it).\n\nYou may also wish to consider instead of/with this extension: Frippery Bottom Panel (already has workspace grid functionality if you want a bottom panel); Frippery Static Workspaces (holds the number of workspaces static and skips all the workspace grid stuff); Remove Workspaces Sidebar; Workspace Indicator Extension (textual indicator/workspace switcher); WorkspaceBar (graphical indicator/workspace switcher); Workspace navigator extension (use arrow keys to navigate workspaces in the Overview).\nSee homepage for more details.",
  "shell-version": [
-     "3.28"
+     "3.28", "3.30"
  ],
  "url": "https://github.com/zakkak/workspace-grid-gnome-shell-extension",
  "dev-version": "1.5.0",

--- a/workspace-grid@mathematical.coffee.gmail.com/myWorkspaceSwitcherPopup.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/myWorkspaceSwitcherPopup.js
@@ -26,6 +26,7 @@ const Clutter = imports.gi.Clutter;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me             = ExtensionUtils.getCurrentExtension();
 const Prefs          = Me.imports.prefs;
+const Utils          = Me.imports.utils;
 
 const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup;
 
@@ -51,7 +52,7 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
     _getPreferredHeight : function (actor, forWidth, alloc) {
         let children    = this._list.get_children(),
             primary     = Main.layoutManager.primaryMonitor,
-            nrows       = global.screen.workspace_grid.rows,
+            nrows       = Utils.WS.getWS().workspace_grid.rows,
             availHeight = primary.height,
             height      = 0,
             spacing     = this._itemSpacing * (nrows - 1);
@@ -61,8 +62,8 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
         availHeight -= this._container.get_theme_node().get_vertical_padding();
         availHeight -= this._list.get_theme_node().get_vertical_padding();
 
-        for (let i = 0; i < global.screen.n_workspaces;
-                i += global.screen.workspace_grid.columns) {
+        for (let i = 0; i < Utils.WS.getWS().n_workspaces;
+                i += Utils.WS.getWS().workspace_grid.columns) {
             let [childMinHeight, childNaturalHeight] =
                 children[i].get_preferred_height(-1);
             children[i].get_preferred_width(childNaturalHeight);
@@ -93,7 +94,7 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
 
     _getPreferredWidth : function (actor, forHeight, alloc) {
         let primary = Main.layoutManager.primaryMonitor,
-            ncols   = global.screen.workspace_grid.columns;
+            ncols   = Utils.WS.getWS().workspace_grid.columns;
         this._childWidth = this._childHeight * primary.width / primary.height;
         let width   = this._childWidth * ncols + this._itemSpacing * (ncols - 1),
             padding = this.actor.get_theme_node().get_horizontal_padding() +
@@ -121,10 +122,10 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
             prevX    = x,
             prevY    = y,
             i        = 0;
-        for (let row = 0; row < global.screen.workspace_grid.rows; ++row) {
+        for (let row = 0; row < Utils.WS.getWS().workspace_grid.rows; ++row) {
             x     = box.x1;
             prevX = x;
-            for (let col = 0; col < global.screen.workspace_grid.columns; ++col) {
+            for (let col = 0; col < Utils.WS.getWS().workspace_grid.columns; ++col) {
                 childBox.x1 = prevX;
                 childBox.x2 = Math.round(x + this._childWidth);
                 childBox.y1 = prevY;
@@ -144,7 +145,7 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
         //log('redisplay, direction ' + this._direction + ', going to ' + this._activeWorkspaceIndex);
         this._list.destroy_all_children();
 
-        for (let i = 0; i < global.screen.n_workspaces; i++) {
+        for (let i = 0; i < Utils.WS.getWS().n_workspaces; i++) {
             let indicator = null;
             let name = Meta.prefs_get_workspace_name(i);
 
@@ -182,7 +183,7 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
         }
 
         let primary = Main.layoutManager.primaryMonitor;
-        let [containerMinHeight, containerNatHeight] = this._container.get_preferred_height(global.screen_width);
+        let [containerMinHeight, containerNatHeight] = this._container.get_preferred_height(primary.width);
         let [containerMinWidth, containerNatWidth] = this._container.get_preferred_width(containerNatHeight);
         this._container.x = primary.x + Math.floor((primary.width - containerNatWidth) / 2);
         this._container.y = primary.y + Main.panel.actor.height +

--- a/workspace-grid@mathematical.coffee.gmail.com/utils.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/utils.js
@@ -1,0 +1,42 @@
+/***********************************************************************
+ * Copyright (C)      2018 Matthieu Baerts <matttbe@gmail.com>         *
+ *                                                                     *
+ * This program is free software: you can redistribute it and/or       *
+ * modify it under the terms of the GNU General Public License as      *
+ * published by the Free Software Foundation, either version 3 of the  *
+ * License, or (at your option) any later version.                     *
+ *                                                                     *
+ * This program is distributed in the hope that it will be useful, but *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU   *
+ * General Public License for more details.                            *
+ *                                                                     *
+ * You should have received a copy of the GNU General Public License   *
+ * along with this program.  If not, see                               *
+ * <http://www.gnu.org/licenses/>.                                     *
+ ***********************************************************************/
+
+const Meta = imports.gi.Meta;
+const ShellVersion = imports.misc.config.PACKAGE_VERSION.split(".");
+const ShellVersionId = (parseInt(ShellVersion[0]) << 8) + parseInt(ShellVersion[1]);
+
+function isVersionAbove(major, minor) {
+    return ShellVersionId > (major << 8) + minor;
+}
+
+// Inspired by https://github.com/micheleg/dash-to-dock/commit/8398d41
+// Maintain compatibility with GNOME-Shell 3.30+ as well as previous versions.
+var WS = {
+    getWS: function() {
+        if (isVersionAbove(3, 28)) {
+            return global.workspace_manager;
+        }
+        return global.screen;
+    },
+    getCorner: function() {
+        if (isVersionAbove(3, 28)) {
+            return Meta.DisplayCorner;
+        }
+        return Meta.ScreenCorner;
+    }
+};


### PR DESCRIPTION
Same as #81 with a fix for ShellVersionId (thanks @zakkak), a rebase and the modification of Readme.org (replaced `global.screen` by `Utils.getWS()`)