### PR TITLE
Remove child actors before destroying parent

### DIFF
--- a/workspace-grid@mathematical.coffee.gmail.com/extension.js
+++ b/workspace-grid@mathematical.coffee.gmail.com/extension.js
@@ -957,6 +957,8 @@ function _replaceThumbnailsBoxActor (actorCallbackObject) {
 
     // kill the old actor
     slider.actor.remove_actor(thumbnailsBox.actor);
+    thumbnailsBox.actor.remove_actor(thumbnailsBox._indicator);
+    thumbnailsBox.actor.remove_actor(thumbnailsBox._dropPlaceholder);
     thumbnailsBox.actor.destroy();
 
     // make our own actor and slot it in to the existing thumbnailsBox.actor


### PR DESCRIPTION
Remove actors registered on the thumbnailsBox actor before destroying and replacing it. These actors are added back after the new actor is created.