### PR TITLE
NPE fix

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1262,7 +1262,9 @@ function disableDynamicWorkspaces() {
     } else {
         settings = global.get_overrides_settings();
     }
-    settings.set_boolean("dynamic-workspaces", false);
+    if (settings) {
+        settings.set_boolean("dynamic-workspaces", false);
+    }
 }
 
 /******************


### PR DESCRIPTION
In #86 there was mention a NPE. On my laptop the NPE rised when unlocking the desktop.

```
říj 22 08:30:12 ntb gnome-shell[3019]: JS ERROR: TypeError: settings is null
                                               disableDynamicWorkspaces@/home/lucky/.local/share/gnome-shell/extensions/workspace-grid@mathematical.coffee.gmail.com/extension.js:1380:5
                                               modifyNumWorkspaces@/home/lucky/.local/share/gnome-shell/extensions/workspace-grid@mathematical.coffee.gmail.com/extension.js:1441:5
```