### PR TITLE
Thumbnails for gridWorkspaceSwitcherPopup

### DIFF
--- a/src/gridWorkspaceSwitcherPopup.js
+++ b/src/gridWorkspaceSwitcherPopup.js
@@ -180,7 +180,7 @@ class gridWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup.WorkspaceSwitche
                 prevX = childBox.x2 + this._itemSpacing;
 
                 if (this.settings.get_boolean(PrefKeys.KEY_SHOW_WORKSPACE_THUMBNAILS)) {
-                    children[i].child.child.set_scale(tbWScale, tbHScale);
+                    children[i].child.get_children()[0].set_scale(tbWScale, tbHScale);
                     children[i].child.allocate(childBox, flags);
                 }
                 children[i].allocate(childBox, flags);
@@ -230,7 +230,7 @@ class gridWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup.WorkspaceSwitche
                 indicator = new St.Bin({ style_class: "ws-switcher-box" });
             }
             if (this.settings.get_boolean(PrefKeys.KEY_SHOW_WORKSPACE_THUMBNAILS)) {
-                let tbBox = new St.Bin({
+                let tbBox = new St.Widget({
                     clip_to_allocation: true,
                     style_class: "ws-switcher-tb-box"
                 });
@@ -246,7 +246,20 @@ class gridWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup.WorkspaceSwitche
                 tb.state = WorkspaceThumbnail.ThumbnailState.NORMAL;
                 tb.actor.clip_to_allocation = false;
 
-                tbBox.child = tb.actor;
+                tbBox.add_child(tb.actor);
+
+                if (this.settings.get_boolean(PrefKeys.KEY_SHOW_WORKSPACE_LABELS)) {
+                    let labelBox = new St.Bin({
+                        style_class: "ws-switcher-label-box"
+                    });
+                    let label = new St.Label({
+                        text: name,
+                        style_class: i === this._activeWorkspaceIndex ? "ws-switcher-label-active" : "ws-switcher-label"
+                    });
+                    labelBox.set_child(label);
+                    tbBox.add_child(labelBox);
+                }
+
                 indicator.child = tbBox;
             }
             else if (this.settings.get_boolean(PrefKeys.KEY_SHOW_WORKSPACE_LABELS)) {

--- a/src/gridWorkspaceSwitcherPopup.js
+++ b/src/gridWorkspaceSwitcherPopup.js
@@ -141,11 +141,17 @@ class gridWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup.WorkspaceSwitche
             prevY = y,
             i = 0;
 
-        let tbPortholeWidth = this._porthole.width - this._porthole.x;
-        let tbPortholeHeight = this._porthole.height - this._porthole.y;
+        let tbPortholeWidth = this._porthole.width - this._porthole.x,
+            tbPortholeHeight = this._porthole.height - this._porthole.y;
 
-        let tbHScale = 0;
-        let tbWScale = 0;
+        let tbHScale = 0,
+            tbWScale = 0;
+
+        let tbBoxThemeNode,
+            tbBoxMarginTop,
+            tbBoxMarginBottom,
+            tbBoxMarginLeft,
+            tbBoxMarginRight;
 
         for (let row = 0; row < Utils.WS.getWS().workspace_grid.rows; ++row) {
             x = box.x1;
@@ -155,25 +161,28 @@ class gridWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup.WorkspaceSwitche
                 col < Utils.WS.getWS().workspace_grid.columns;
                 ++col
             ) {
-                let tbBoxThemeNode = children[i].child.get_theme_node();
-                let tbBoxMarginTop = tbBoxThemeNode.get_margin(St.Side.TOP);
-                let tbBoxMarginBottom = tbBoxThemeNode.get_margin(St.Side.BOTTOM);
-                let tbBoxMarginLeft = tbBoxThemeNode.get_margin(St.Side.LEFT);
-                let tbBoxMarginRight = tbBoxThemeNode.get_margin(St.Side.RIGHT);
-
                 childBox.x1 = prevX;
                 childBox.x2 = Math.round(x + this._childWidth);
                 childBox.y1 = prevY;
                 childBox.y2 = Math.round(y + this._childHeight);
 
-                tbWScale = (childBox.x2 - childBox.x1 - tbBoxMarginLeft - tbBoxMarginRight) / tbPortholeWidth;
-                tbHScale = (childBox.y2 - childBox.y1 - tbBoxMarginTop - tbBoxMarginBottom) / tbPortholeHeight;
+                if (this.settings.get_boolean(PrefKeys.KEY_SHOW_WORKSPACE_THUMBNAILS)) {
+                    tbBoxThemeNode = children[i].child.get_theme_node();
+                    tbBoxMarginTop = tbBoxThemeNode.get_margin(St.Side.TOP);
+                    tbBoxMarginBottom = tbBoxThemeNode.get_margin(St.Side.BOTTOM);
+                    tbBoxMarginLeft = tbBoxThemeNode.get_margin(St.Side.LEFT);
+                    tbBoxMarginRight = tbBoxThemeNode.get_margin(St.Side.RIGHT);
+                    tbWScale = (childBox.x2 - childBox.x1 - tbBoxMarginLeft - tbBoxMarginRight) / tbPortholeWidth;
+                    tbHScale = (childBox.y2 - childBox.y1 - tbBoxMarginTop - tbBoxMarginBottom) / tbPortholeHeight;
+                }
 
                 x += this._childWidth + this._itemSpacing;
                 prevX = childBox.x2 + this._itemSpacing;
 
-                children[i].child.child.set_scale(tbWScale, tbHScale);
-                children[i].child.allocate(childBox, flags);
+                if (this.settings.get_boolean(PrefKeys.KEY_SHOW_WORKSPACE_THUMBNAILS)) {
+                    children[i].child.child.set_scale(tbWScale, tbHScale);
+                    children[i].child.allocate(childBox, flags);
+                }
                 children[i].allocate(childBox, flags);
 
                 i++;
@@ -220,11 +229,7 @@ class gridWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup.WorkspaceSwitche
             } else {
                 indicator = new St.Bin({ style_class: "ws-switcher-box" });
             }
-            if (this.settings.get_boolean(PrefKeys.KEY_SHOW_WORKSPACE_LABELS)) {
-                /*indicator.child = new St.Label({
-                    text: name,
-                    style_class: "ws-switcher-label"
-                });*/
+            if (this.settings.get_boolean(PrefKeys.KEY_SHOW_WORKSPACE_THUMBNAILS)) {
                 let tbBox = new St.Bin({
                     clip_to_allocation: true,
                     style_class: "ws-switcher-tb-box"
@@ -244,7 +249,12 @@ class gridWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup.WorkspaceSwitche
                 tbBox.child = tb.actor;
                 indicator.child = tbBox;
             }
-
+            else if (this.settings.get_boolean(PrefKeys.KEY_SHOW_WORKSPACE_LABELS)) {
+                indicator.child = new St.Label({
+                    text: name,
+                    style_class: "ws-switcher-label"
+                });
+            }
             this._list.add_actor(indicator);
         }
 

--- a/src/prefKeys.js
+++ b/src/prefKeys.js
@@ -25,5 +25,6 @@ const KEY_WRAP_TO_SAME_SCROLL = "wrap-to-same-scroll";
 const KEY_MAX_HFRACTION = "max-screen-fraction";
 const KEY_MAX_HFRACTION_COLLAPSE = "max-screen-fraction-before-collapse";
 const KEY_SHOW_WORKSPACE_LABELS = "show-workspace-labels";
+const KEY_SHOW_WORKSPACE_THUMBNAILS = "show-workspace-thumbnails";
 const KEY_RELATIVE_WORKSPACE_SWITCHING = "relative-workspace-switching";
 const KEY_SCROLL_DIRECTION = "scroll-direction";

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -46,6 +46,7 @@ var KEY_WRAP_TO_SAME_SCROLL = PrefKeys.KEY_WRAP_TO_SAME_SCROLL;
 var KEY_MAX_HFRACTION = PrefKeys.KEY_MAX_HFRACTION;
 var KEY_MAX_HFRACTION_COLLAPSE = PrefKeys.KEY_MAX_HFRACTION_COLLAPSE;
 var KEY_SHOW_WORKSPACE_LABELS = PrefKeys.KEY_SHOW_WORKSPACE_LABELS;
+var KEY_SHOW_WORKSPACE_THUMBNAILS = PrefKeys.KEY_SHOW_WORKSPACE_THUMBNAILS;
 var KEY_RELATIVE_WORKSPACE_SWITCHING =
     PrefKeys.KEY_RELATIVE_WORKSPACE_SWITCHING;
 var KEY_SCROLL_DIRECTION = PrefKeys.KEY_SCROLL_DIRECTION;
@@ -136,6 +137,11 @@ const WorkspaceGridPrefsWidget = GObject.registerClass(
             this.addBoolean(
                 _("Show workspace labels in the switcher?"),
                 KEY_SHOW_WORKSPACE_LABELS
+            );
+
+            this.addBoolean(
+                _("Show workspace thumbnails in the switcher?"),
+                KEY_SHOW_WORKSPACE_THUMBNAILS
             );
 
             this.addTextComboBox("Scroll Direction: ", KEY_SCROLL_DIRECTION, [

--- a/src/schemas/org.gnome.shell.extensions.workspace-grid.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.workspace-grid.gschema.xml
@@ -38,6 +38,11 @@
       <summary>Whether to show workspace names in the workspace switcher popup</summary>
       <description>Whether to show workspace names in the workspace switcher popup</description>
     </key>
+    <key type="b" name="show-workspace-thumbnails">
+      <default>true</default>
+      <summary>Whether to show workspace thumbnails in the workspace switcher popup</summary>
+      <description>Whether to show workspace thumbnails in the workspace switcher popup</description>
+    </key>
     <key type="d" name="max-screen-fraction">
       <default>0.7</default>
       <range min="0" max="1.0"/>

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -37,6 +37,10 @@
     padding: 10px;
 }
 
+.ws-switcher-tb-box {
+    margin: 10px;
+}
+
 /* Note:
  * .ws-switcher-active-{up,down} are already in the global .css so we override them here.
  */

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -64,8 +64,18 @@
     background-color: rgba(32, 96, 152, 0.8);
 }
 
+.ws-switcher-label-box {
+    background-color: rgba(32, 96, 152, 0.8);
+    padding: 5px;
+}
+
 .ws-switcher-label {
     color: rgba(255, 255, 255, 0.80);
+    font-size: 2em;
+}
+
+.ws-switcher-label-active {
+    color: rgba(255, 0, 0, 1);
     font-size: 2em;
 }
 


### PR DESCRIPTION
**Motivations:**
- The switcher does not preview the workspaces.
- The "thumbnails" branch does not work with Gnome Shell 3.28.3, which comes with Ubuntu18.04.
- Other switcher extensions do not compatible with this extension. I guess that it is due to this extension modifies the original imports.ui.workspaceThumbnail.ThumbnailsBox at runtime.

**Proposal:**
- Base the implementation from 3.30 branch. 
- Introduce KEY_SHOW_WORKSPACE_THUMBNAILS in the preference, as done in the thumbnails branch.
- Use imports.ui.workspaceThumbnail.WorkspaceThumbnail directly in gridWorkspaceSwitcherPopup.
- Make KEY_SHOW_WORKSPACE_LABELS and KEY_SHOW_WORKSPACE_THUMBNAILS compatible. Users can enable both features at the same time, enable only one at a time, or disable both of them.
- Compatible with moving a window from one workspace to another.
- Show highlight for the workspace that the screen is moving to.

**Tests:**
- On my machine with Ubuntu18.04, Gnome Shell 3.28.3.

**Previews:**
![Screenshot from 2019-05-20 20-12-19](https://user-images.githubusercontent.com/22335930/58065787-b1ee9280-7b3b-11e9-86c3-d923b623ce16.png)
